### PR TITLE
fix(picker-column): emit first change event

### DIFF
--- a/src/components/picker/picker-column.ts
+++ b/src/components/picker/picker-column.ts
@@ -404,11 +404,7 @@ export class PickerColumnCmp {
     }
 
     if (emitChange) {
-      if (this.lastIndex === undefined) {
-        // have not set a last index yet
-        this.lastIndex = this.col.selectedIndex;
-
-      } else if (this.lastIndex !== this.col.selectedIndex) {
+      if (this.lastIndex !== this.col.selectedIndex) {
         // new selected index has changed from the last index
         // update the lastIndex and emit that it has changed
         this.lastIndex = this.col.selectedIndex;


### PR DESCRIPTION
#### Short description of what this resolves:

The first "change" event from the `PickerColumnCmp` is not being emitted. The selected value is being updated behind the scenes, but the change is not communicated to the parent component/page.

This is not a bug in the way Ionic uses the component because the picker component doesn't update the input field value as the user changes the picker column – the input field is updated once the user clicks the "Done" button (https://i.gyazo.com/bdea4dc2f68c2b510b2c6fd231fe5fd3.mp4).

But it is a bug if you try to use the columns directly in another page/component and not as part of the `PickerComponent`

#### Changes proposed in this pull request:

Emit the first change event
